### PR TITLE
Remove requirements from Release Notes

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,12 +1,4 @@
-Check requirements before installing:
-<ul>
-<li>DotNetNuke 7.2 or later</li>
-<li>.NET Framework 4</li>
-<li>IIS 7.0</li>
-<li>SQL Server 2008 or later</li>
-<li>Recommended: Razor installed (see <a href="http://swisschecklist.com/en/j3zng2ko/Bin-Deploying-ASP.NET-MVC-3" target="_blank">checklist</a>)</li>
-</ul>
 For help installing this module correctly click <a href="http://swisschecklist.com/en/rh7ew1ms/Install-2Sexy-Content-Module-for-DotNetNuke" target="_blank">here</a><br />
 <br />
 <hr />
-<p><a href="http://sexycontent.codeplex.com/wikipage?title=Release%20Notes" target="_blank">Release notes on CodePlex</a></p>
+<p>Read the <a href="http://sexycontent.codeplex.com/wikipage?title=Release%20Notes" target="_blank">release notes on CodePlex</a></p>


### PR DESCRIPTION
The minimum version of DNN is enforced by the installer, _before_ the release notes are displayed, and all of the other requirements are DNN 7 requirements, so they, too, will need to be satisfied by the time the release notes are displayed.

I'd also suggest removing the link to the checklist, since it's mostly the same basic instructions (but more out of date), but I'll leave that decision to you.
